### PR TITLE
The fix for issue https://github.com/sgroschupf/aws-tasks/issues/3

### DIFF
--- a/src/examples/ant/build.ec2.xml
+++ b/src/examples/ant/build.ec2.xml
@@ -29,8 +29,8 @@
 			instanceType="m1.small" 
 			userData="a | b | c"
 			availabilityZone="us-east-1c">
-			<groupPermission protocol="tcp" fromPort="22" toPort="22" sourceIpOrGroup="0.0.0.0/0"/>
-			<groupPermission protocol="tcp" fromPort="10023" sourceIpOrGroup="0.0.0.0/0"/>
+			<groupPermission protocol="tcp" fromPort="22" toPort="22" sourceIp="0.0.0.0/0"/>
+			<groupPermission protocol="tcp" fromPort="10023" sourceIp="0.0.0.0/0"/>
 		</ec2-start>
 	</target>
 	

--- a/src/main/java/datameer/awstasks/ant/ec2/Ec2StartTask.java
+++ b/src/main/java/datameer/awstasks/ant/ec2/Ec2StartTask.java
@@ -160,6 +160,7 @@ public class Ec2StartTask extends AbstractEc2Task {
     @Override
     public void execute() throws BuildException {
         System.out.println("executing " + getClass().getSimpleName() + " with groupName '" + _groupName + "'");
+        validate();
         AmazonEC2 ec2 = createEc2();
         try {
             boolean instancesRunning = Ec2Util.findByGroup(ec2, _groupName, false, InstanceStateName.Pending, InstanceStateName.Running) != null;
@@ -222,6 +223,14 @@ public class Ec2StartTask extends AbstractEc2Task {
             }
         } catch (Exception e) {
             throw new BuildException(e);
+        }
+    }
+
+    private void validate() {
+        for (GroupPermission groupPermission : _groupPermissions) {
+            if (null != groupPermission.getSourceIp() || groupPermission.getSourceIp().trim().length() == 0) {
+                throw new BuildException("GroupPermission '" + groupPermission + "' has no attribute 'sourceIp'.");
+            }
         }
     }
 

--- a/src/test/java/datameer/awstasks/ant/ec2/GroupPermissionTest.java
+++ b/src/test/java/datameer/awstasks/ant/ec2/GroupPermissionTest.java
@@ -1,0 +1,47 @@
+package datameer.awstasks.ant.ec2;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import com.amazonaws.services.ec2.model.IpPermission;
+import com.amazonaws.services.ec2.model.UserIdGroupPair;
+
+import datameer.awstasks.aws.ec2.GroupPermission;
+
+public class GroupPermissionTest {
+
+    @Test
+    public void testMatches_ips() {
+        GroupPermission groupPermission = new GroupPermission("tcp", 1433, 1433, "0.0.0.0/0");
+        IpPermission ipPermission = new IpPermission();
+        ipPermission.setIpProtocol("tcp");
+        ipPermission.setToPort(65535);
+        ipPermission.setFromPort(0);
+        Collection<String> ips = new ArrayList<String>();
+        ips.add("127.0.0.1");
+        ipPermission.setIpRanges(ips);
+        assertFalse(groupPermission.matches(ipPermission));
+
+        ips.clear();
+        ips.add("0.0.0.0/0");
+        ipPermission.setIpRanges(ips);
+        assertTrue(groupPermission.matches(ipPermission));
+    }
+
+    @Test
+    public void testMatches_groupWithSamePort() {
+        GroupPermission groupPermission = new GroupPermission("tcp", 1433, 1433, "0.0.0.0/0");
+        IpPermission ipPermission = new IpPermission();
+        ipPermission.setIpProtocol("tcp");
+        ipPermission.setToPort(65535);
+        ipPermission.setFromPort(0);
+        Collection<UserIdGroupPair> ips = new ArrayList<UserIdGroupPair>();
+        ips.add(new UserIdGroupPair().withGroupId("0.0.0.0/0").withGroupName("0.0.0.0/0").withUserId("0.0.0.0/0"));
+        ipPermission.setUserIdGroupPairs(ips);
+        assertFalse(groupPermission.matches(ipPermission));
+    }
+}


### PR DESCRIPTION
- rename _sourceIpOrGroup to _sourceIp to refelct better that it is only used for ip ranges
- include ip ranges in permission comparison to avoid false positive
- validate for setted sourceIp property before executing ec2 start task
