### PR TITLE
DAP-18662: SFTP Export - Channel is not Open

### DIFF
--- a/src/main/java/datameer/awstasks/ssh/JschRunner.java
+++ b/src/main/java/datameer/awstasks/ssh/JschRunner.java
@@ -318,6 +318,7 @@ public class JschRunner extends ShellExecutor {
             ChannelExec testChannel = (ChannelExec) cachedSession.openChannel("exec");
             testChannel.connect();
             testChannel.setCommand("true");
+            testChannel.disconnect();
             return true;
         } catch (Exception e) {
             LOG.info("Session is connected but cannot be used and needs to be recreated.");


### PR DESCRIPTION
Fixing a problem where a session is not connected although isConnected returned true.

See: http://stackoverflow.com/questions/16127200/jsch-how-to-keep-the-session-alive-and-up
