### PR TITLE
call Jsch#setKnownHosts() only if the file exists

### DIFF
--- a/src/main/java/datameer/awstasks/ssh/JschRunner.java
+++ b/src/main/java/datameer/awstasks/ssh/JschRunner.java
@@ -328,7 +328,7 @@ public class JschRunner extends ShellExecutor {
             jsch.addIdentity(identity, null);
         }
 
-        if (!_trust && _knownHosts != null) {
+        if (!_trust && _knownHosts != null && new File(_knownHosts).exists()) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Using known hosts: " + _knownHosts);
             }


### PR DESCRIPTION
@jzillmann hey, Jsch fails if the argument to setKnownHosts() is a non-existng file, we should check before setting it